### PR TITLE
Fix resdatproc dummy entry handling

### DIFF
--- a/tools/dataproc/src/resdatproc.c
+++ b/tools/dataproc/src/resdatproc.c
@@ -133,7 +133,11 @@ int main(int argc, char **argv) {
 int sort_strcmp(const void *lhs, const void *rhs) {
     const lookup_t *l = lhs;
     const lookup_t *r = rhs;
-    if (l->def == NULL || r->def == NULL) return 0;
+
+    if (l->def == NULL && r->def == NULL) return 0;
+    else if (l->def == NULL) return 1;
+    else if (r->def == NULL) return -1;
+
     return strcmp(l->def, r->def);
 }
 


### PR DESCRIPTION
Quick fix for the handling of dummy entries in resdatproc, by toughening up the comparison function used when sorting the resulting resource lookup map.

This forces NULL entries in this map to be placed at the end after sorting, after all valid entries.

On some systems, the result of the quick sort of this map leads to NULL entries preventing the map from being correctly sorted, which leads to the binary search failing downhill.